### PR TITLE
Dockerfile: Support multiple stage build in manager and cli

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,5 +11,5 @@ docker build -t ${PREFIX}katib-frontend -f manager/modeldb/Dockerfile .
 docker build -t ${PREFIX}katib-cli -f cli/Dockerfile .
 mkdir -p bin
 docker run --name katib-cli -itd ${PREFIX}katib-cli sh
-docker cp katib-cli:/go/src/github.com/kubeflow/hp-tuning/cli/katib-cli bin/katib-cli 
+docker cp katib-cli:/go/src/github.com/kubeflow/hp-tuning/cli/katib-cli bin/katib-cli
 docker rm -f katib-cli

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,22 +1,9 @@
-FROM golang
-RUN : && \
-    go get k8s.io/api/apps/v1beta1 && \
-    go get k8s.io/api/core/v1 && \
-    go get k8s.io/apimachinery/pkg/apis/meta/v1 && \
-    go get k8s.io/client-go/kubernetes && \
-    go get k8s.io/client-go/tools/clientcmd && \
-    go get k8s.io/client-go/util/homedir && \
-    go get k8s.io/client-go/util/retry && \
-    go get k8s.io/client-go/rest && \
-    go get k8s.io/apimachinery/pkg/runtime/serializer && \
-    go get database/sql && \
-    go get github.com/golang/protobuf/jsonpb && \
-    go get github.com/go-sql-driver/mysql && \
-    go get github.com/mattn/go-sqlite3 && \
-    go get google.golang.org/grpc && \
-    go get gopkg.in/yaml.v2 && \
-    :
-ADD api $GOPATH/src/github.com/kubeflow/hp-tuning/api
-ADD cli $GOPATH/src/github.com/kubeflow/hp-tuning/cli
-WORKDIR $GOPATH/src/github.com/kubeflow/hp-tuning/cli
+FROM golang:1.8.2 AS build-env
+# The GOPATH in the image is /go.
+ADD . /go/src/github.com/kubeflow/hp-tuning
+WORKDIR /go/src/github.com/kubeflow/hp-tuning/cli
 RUN go build -o katib-cli
+
+FROM centos:7
+WORKDIR /app
+COPY --from=build-env /go/src/github.com/kubeflow/hp-tuning/cli/katib-cli /app/

--- a/docs/getting-start.md
+++ b/docs/getting-start.md
@@ -13,7 +13,7 @@ First, Copy CLI tool.
 ```bash
 docker pull katib/katib-cli
 docker run --name katib-cli -itd katib/katib-cli sh
-docker cp katib-cli:/go/src/github.com/kubeflow/hp-tuning/cli/katib-cli bin/katib-cli
+docker cp katib-cli:/app/katib-cli bin/katib-cli
 docker rm -f katib-cli
 ```
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,33 +1,11 @@
-FROM golang
-RUN : && \
-    go get k8s.io/api/apps/v1beta1 && \
-    go get k8s.io/api/core/v1 && \
-    go get k8s.io/apimachinery/pkg/apis/meta/v1 && \
-    go get k8s.io/client-go/kubernetes && \
-    go get k8s.io/client-go/tools/clientcmd && \
-    go get k8s.io/client-go/util/homedir && \
-    go get k8s.io/client-go/util/retry && \
-    go get k8s.io/client-go/rest && \
-    go get k8s.io/apimachinery/pkg/runtime/serializer && \
-    go get database/sql && \
-    go get github.com/golang/protobuf/jsonpb && \
-    go get github.com/go-sql-driver/mysql && \
-    go get github.com/mattn/go-sqlite3 && \
-    go get google.golang.org/grpc && \
-    go get github.com/sirupsen/logrus && \
-    go get github.com/docker/docker/api/types && \
-    go get github.com/docker/docker/api/types/container && \
-    go get github.com/docker/docker/client && \
-    :
-RUN apt update && apt install -y python python-pip
-RUN pip install modeldb
-ADD api $GOPATH/src/github.com/kubeflow/hp-tuning/api
-ADD db $GOPATH/src/github.com/kubeflow/hp-tuning/db
-ADD manager $GOPATH/src/github.com/kubeflow/hp-tuning/manager
-ADD dlk $GOPATH/src/github.com/kubeflow/hp-tuning/dlk
-ADD earlystopping $GOPATH/src/github.com/kubeflow/hp-tuning/earlystopping
-ADD conf /conf
-ADD manager/wrap.sh /wrap.sh
-RUN chmod 755 /wrap.sh
-WORKDIR $GOPATH/src/github.com/kubeflow/hp-tuning/manager
+FROM golang:alpine AS build-env
+# The GOPATH in the image is /go.
+ADD . /go/src/github.com/kubeflow/hp-tuning
+WORKDIR /go/src/github.com/kubeflow/hp-tuning/manager
 RUN go build -o vizier-manager
+
+FROM alpine:3.7
+WORKDIR /app
+COPY --from=build-env /go/src/github.com/kubeflow/hp-tuning/manager/vizier-manager /app/
+ENTRYPOINT ["./vizier-manager"]
+CMD ["-w", "dlk"]

--- a/manifests/vizier/core/deployment.yaml
+++ b/manifests/vizier/core/deployment.yaml
@@ -20,7 +20,6 @@ spec:
       - name: vizier-core
         image: katib/vizier-core
         args:
-          - './vizier-manager'
           - "-w"
           - "dlk"
         ports:


### PR DESCRIPTION
Same as #23 

I am not sure if we should copy the CLI from the docker container. But I follow the convention to use centos instead of alpine to get the runnable binary from the container.

/assign @YujiOshima 